### PR TITLE
Modify android HTTP upload sequence for uniformity with IOS

### DIFF
--- a/src/android/com/synconset/cordovahttp/CordovaHttpUpload.java
+++ b/src/android/com/synconset/cordovahttp/CordovaHttpUpload.java
@@ -54,8 +54,6 @@ class CordovaHttpUpload extends CordovaHttp implements Runnable {
             MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
             String mimeType = mimeTypeMap.getMimeTypeFromExtension(ext);
 
-            request.part(this.name, filename, mimeType, new File(uri));
-
             Set<?> set = (Set<?>)this.getParamsMap().entrySet();
             Iterator<?> i = set.iterator();
 
@@ -72,6 +70,8 @@ class CordovaHttpUpload extends CordovaHttp implements Runnable {
                     return;
                 }
             }
+          
+            request.part(this.name, filename, mimeType, new File(uri));
 
             this.returnResponseObject(request);
         } catch (URISyntaxException e) {


### PR DESCRIPTION
Hi

The Android Cordova-plugin-advanced-http 'upload' sequence was modified:
- to respect the order of operations some sites requires, like amazonaws.com
- to have the same behavior as it's IOS counterpart.

We've observed this behavior while successfully performing updates on Amazon S3 but failing on Android.

Thanks for your consideration